### PR TITLE
Enhance ErrorOr functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -785,6 +785,41 @@ public class ValidationBehavior<TRequest, TResponse>(IValidator<TRequest>? valid
 }
 ```
 
+# Enhancements
+
+## Creating `ErrorOr` instances from tuples and custom objects
+
+The `ErrorOrFactory` class now includes additional factory methods to create `ErrorOr` instances from tuples and custom objects. This provides more flexibility and convenience when creating `ErrorOr` instances.
+
+### Example
+
+```cs
+var errorOr = ErrorOrFactory.FromTuple((1, "value"));
+var errorOr = ErrorOrFactory.FromCustomObject(new CustomObject { Id = 1, Name = "value" });
+```
+
+## Improved error handling
+
+The `ErrorType` enum now includes more specific error types for granular error handling. The `Error` struct also includes corresponding factory methods for the new error types.
+
+### Example
+
+```cs
+var error = Error.ValidationError("Validation error occurred");
+var error = Error.DatabaseError("Database error occurred");
+```
+
+## Additional extension methods
+
+The `ErrorOr` extension files now include additional extension methods for enhanced functionality. These methods provide additional functionality, such as chaining operations, transforming values, or handling errors in different ways.
+
+### Example
+
+```cs
+var result = errorOr.Then(value => value * 2)
+                   .Else(errors => Error.Unexpected("Unexpected error occurred"));
+```
+
 # Contribution 🤲
 
 If you have any questions, comments, or suggestions, please open an issue or create a pull request 🙂
@@ -795,4 +830,4 @@ If you have any questions, comments, or suggestions, please open an issue or cre
 
 # License 🪪
 
-This project is licensed under the terms of the [MIT](https://github.com/mantinband/error-or/blob/main/LICENSE) license.
+This project is licensed under the terms of the [MIT](://github.com/mantinband/error-or/blob/main/LICENSE) license.

--- a/src/ErrorOr/ErrorOr.AggregationExtensions.cs
+++ b/src/ErrorOr/ErrorOr.AggregationExtensions.cs
@@ -35,5 +35,45 @@ namespace ErrorOr.ErrorOr
             // If there are errors, return a new ErrorOr<TValue> instance with those errors.
             return combinedErrors.Count > 0 ? ErrorOr<TValue>.FromError(combinedErrors) : errorOr;
         }
+
+        /// <summary>
+        /// Appends errors from multiple <see cref="IErrorOr"/> instances into the current <see cref="ErrorOr{TValue}"/> instance,
+        /// and includes additional metadata for enhanced error handling.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the underlying value in the <paramref name="errorOr"/>.</typeparam>
+        /// <param name="errorOr">The current <see cref="ErrorOr{TValue}"/> instance.</param>
+        /// <param name="metadata">Additional metadata to include with the errors.</param>
+        /// <param name="errors">The additional <see cref="IErrorOr"/> instances whose errors need to be appended.</param>
+        /// <returns>A new <see cref="ErrorOr{TValue}"/> instance containing all combined errors with metadata, or the original if no errors are added.</returns>
+        public static ErrorOr<TValue> AppendErrorsWithMetadata<TValue>(
+            this ErrorOr<TValue> errorOr,
+            Dictionary<string, object> metadata,
+            params IErrorOr[]? errors)
+        {
+            // Guard clause to handle null or empty errors array.
+            if (errors is null || errors.Length == 0)
+            {
+                return errorOr;
+            }
+
+            // Start with the errors from the current ErrorOr instance.
+            var combinedErrors = new List<Error>(errorOr.ErrorsOrEmptyList);
+
+            // Add errors from the additional ErrorOr instances if they contain errors.
+            foreach (var error in errors)
+            {
+                if (error?.IsError == true)
+                {
+                    // Add errors from error instances that are in an error state
+                    combinedErrors.AddRange(error.Errors ?? Enumerable.Empty<Error>());
+                }
+            }
+
+            // Add metadata to each error
+            var enhancedErrors = combinedErrors.Select(e => e with { Metadata = metadata }).ToList();
+
+            // If there are errors, return a new ErrorOr<TValue> instance with those errors and metadata.
+            return enhancedErrors.Count > 0 ? ErrorOr<TValue>.FromError(enhancedErrors) : errorOr;
+        }
     }
 }

--- a/src/ErrorOr/ErrorOr.Else.cs
+++ b/src/ErrorOr/ErrorOr.Else.cs
@@ -151,4 +151,89 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
         return await onError.ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// If the state is error, the provided function <paramref name="onError"/> is executed and its result is returned.
+    /// </summary>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
+    public ErrorOr<TValue> ElseWithMetadata(Func<List<Error>, Error> onError, Dictionary<string, object> metadata)
+    {
+        if (!IsError)
+        {
+            return Value;
+        }
+
+        var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+        return onError(enhancedErrors);
+    }
+
+    /// <summary>
+    /// If the state is error, the provided function <paramref name="onError"/> is executed and its result is returned.
+    /// </summary>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
+    public ErrorOr<TValue> ElseWithMetadata(Func<List<Error>, List<Error>> onError, Dictionary<string, object> metadata)
+    {
+        if (!IsError)
+        {
+            return Value;
+        }
+
+        var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+        return onError(enhancedErrors);
+    }
+
+    /// <summary>
+    /// If the state is error, the provided function <paramref name="onError"/> is executed asynchronously and its result is returned.
+    /// </summary>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
+    public async Task<ErrorOr<TValue>> ElseWithMetadataAsync(Func<List<Error>, Task<TValue>> onError, Dictionary<string, object> metadata)
+    {
+        if (!IsError)
+        {
+            return Value;
+        }
+
+        var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+        return await onError(enhancedErrors).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// If the state is error, the provided function <paramref name="onError"/> is executed asynchronously and its result is returned.
+    /// </summary>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
+    public async Task<ErrorOr<TValue>> ElseWithMetadataAsync(Func<List<Error>, Task<Error>> onError, Dictionary<string, object> metadata)
+    {
+        if (!IsError)
+        {
+            return Value;
+        }
+
+        var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+        return await onError(enhancedErrors).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// If the state is error, the provided function <paramref name="onError"/> is executed asynchronously and its result is returned.
+    /// </summary>
+    /// <param name="onError">The function to execute if the state is error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The result from calling <paramref name="onError"/> if state is error; otherwise the original <see cref="Value"/>.</returns>
+    public async Task<ErrorOr<TValue>> ElseWithMetadataAsync(Func<List<Error>, Task<List<Error>>> onError, Dictionary<string, object> metadata)
+    {
+        if (!IsError)
+        {
+            return Value;
+        }
+
+        var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+        return await onError(enhancedErrors).ConfigureAwait(false);
+    }
 }

--- a/src/ErrorOr/ErrorOr.FailIf.cs
+++ b/src/ErrorOr/ErrorOr.FailIf.cs
@@ -69,4 +69,102 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
         return await onValue(Value).ConfigureAwait(false) ? await errorBuilder(Value).ConfigureAwait(false) : this;
     }
+
+    /// <summary>
+    /// If the state is value, the provided function <paramref name="onValue"/> is invoked.
+    /// If <paramref name="onValue"/> returns true, the given <paramref name="error"/> will be returned, and the state will be error.
+    /// </summary>
+    /// <param name="onValue">The function to execute if the state is value.</param>
+    /// <param name="error">The <see cref="Error"/> to return if the given <paramref name="onValue"/> function returned true.</param>
+    /// <param name="metadata">Additional metadata to include with the error.</param>
+    /// <returns>The given <paramref name="error"/> with metadata if <paramref name="onValue"/> returns true; otherwise, the original <see cref="ErrorOr"/> instance.</returns>
+    public ErrorOr<TValue> FailIfWithMetadata(Func<TValue, bool> onValue, Error error, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            return this;
+        }
+
+        if (onValue(Value))
+        {
+            var enhancedError = error with { Metadata = metadata };
+            return enhancedError;
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// If the state is value, the provided function <paramref name="onValue"/> is invoked.
+    /// If <paramref name="onValue"/> returns true, the given <paramref name="errorBuilder"/> function will be executed, and the state will be error.
+    /// </summary>
+    /// <param name="onValue">The function to execute if the state is value.</param>
+    /// <param name="errorBuilder">The error builder function to execute and return if the given <paramref name="onValue"/> function returned true.</param>
+    /// <param name="metadata">Additional metadata to include with the error.</param>
+    /// <returns>The given <paramref name="errorBuilder"/> functions return value with metadata if <paramref name="onValue"/> returns true; otherwise, the original <see cref="ErrorOr"/> instance.</returns>
+    public ErrorOr<TValue> FailIfWithMetadata(Func<TValue, bool> onValue, Func<TValue, Error> errorBuilder, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            return this;
+        }
+
+        if (onValue(Value))
+        {
+            var error = errorBuilder(Value);
+            var enhancedError = error with { Metadata = metadata };
+            return enhancedError;
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// If the state is value, the provided function <paramref name="onValue"/> is invoked asynchronously.
+    /// If <paramref name="onValue"/> returns true, the given <paramref name="error"/> will be returned, and the state will be error.
+    /// </summary>
+    /// <param name="onValue">The function to execute if the statement is value.</param>
+    /// <param name="error">The <see cref="Error"/> to return if the given <paramref name="onValue"/> function returned true.</param>
+    /// <param name="metadata">Additional metadata to include with the error.</param>
+    /// <returns>The given <paramref name="error"/> with metadata if <paramref name="onValue"/> returns true; otherwise, the original <see cref="ErrorOr"/> instance.</returns>
+    public async Task<ErrorOr<TValue>> FailIfWithMetadataAsync(Func<TValue, Task<bool>> onValue, Error error, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            return this;
+        }
+
+        if (await onValue(Value).ConfigureAwait(false))
+        {
+            var enhancedError = error with { Metadata = metadata };
+            return enhancedError;
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// If the state is value, the provided function <paramref name="onValue"/> is invoked asynchronously.
+    /// If <paramref name="onValue"/> returns true, the given <paramref name="errorBuilder"/> function will be executed, and the state will be error.
+    /// </summary>
+    /// <param name="onValue">The function to execute if the state is value.</param>
+    /// <param name="errorBuilder">The error builder function to execute and return if the given <paramref name="onValue"/> function returned true.</param>
+    /// <param name="metadata">Additional metadata to include with the error.</param>
+    /// <returns>The given <paramref name="errorBuilder"/> functions return value with metadata if <paramref name="onValue"/> returns true; otherwise, the original <see cref="ErrorOr"/> instance.</returns>
+    public async Task<ErrorOr<TValue>> FailIfWithMetadataAsync(Func<TValue, Task<bool>> onValue, Func<TValue, Task<Error>> errorBuilder, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            return this;
+        }
+
+        if (await onValue(Value).ConfigureAwait(false))
+        {
+            var error = await errorBuilder(Value).ConfigureAwait(false);
+            var enhancedError = error with { Metadata = metadata };
+            return enhancedError;
+        }
+
+        return this;
+    }
 }

--- a/src/ErrorOr/ErrorOr.Match.cs
+++ b/src/ErrorOr/ErrorOr.Match.cs
@@ -77,4 +77,88 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
         return await onValue(Value).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Executes the appropriate function based on the state of the <see cref="ErrorOr{TValue}"/>.
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed and its result is returned.
+    /// If the state is an error, the provided function <paramref name="onError"/> is executed and its result is returned.
+    /// </summary>
+    /// <typeparam name="TNextValue">The type of the result.</typeparam>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <param name="onError">The function to execute if the state is an error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The result of the executed function.</returns>
+    public TNextValue MatchWithMetadata<TNextValue>(Func<TValue, TNextValue> onValue, Func<List<Error>, TNextValue> onError, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+            return onError(enhancedErrors);
+        }
+
+        return onValue(Value);
+    }
+
+    /// <summary>
+    /// Asynchronously executes the appropriate function based on the state of the <see cref="ErrorOr{TValue}"/>.
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its result is returned.
+    /// If the state is an error, the provided function <paramref name="onError"/> is executed asynchronously and its result is returned.
+    /// </summary>
+    /// <typeparam name="TNextValue">The type of the result.</typeparam>
+    /// <param name="onValue">The asynchronous function to execute if the state is a value.</param>
+    /// <param name="onError">The asynchronous function to execute if the state is an error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>A task representing the asynchronous operation that yields the result of the executed function.</returns>
+    public async Task<TNextValue> MatchWithMetadataAsync<TNextValue>(Func<TValue, Task<TNextValue>> onValue, Func<List<Error>, Task<TNextValue>> onError, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+            return await onError(enhancedErrors).ConfigureAwait(false);
+        }
+
+        return await onValue(Value).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes the appropriate function based on the state of the <see cref="ErrorOr{TValue}"/>.
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed and its result is returned.
+    /// If the state is an error, the provided function <paramref name="onFirstError"/> is executed using the first error, and its result is returned.
+    /// </summary>
+    /// <typeparam name="TNextValue">The type of the result.</typeparam>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <param name="onFirstError">The function to execute with the first error if the state is an error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The result of the executed function.</returns>
+    public TNextValue MatchFirstWithMetadata<TNextValue>(Func<TValue, TNextValue> onValue, Func<Error, TNextValue> onFirstError, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedError = FirstError with { Metadata = metadata };
+            return onFirstError(enhancedError);
+        }
+
+        return onValue(Value);
+    }
+
+    /// <summary>
+    /// Asynchronously executes the appropriate function based on the state of the <see cref="ErrorOr{TValue}"/>.
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its result is returned.
+    /// If the state is an error, the provided function <paramref name="onFirstError"/> is executed asynchronously using the first error, and its result is returned.
+    /// </summary>
+    /// <typeparam name="TNextValue">The type of the result.</typeparam>
+    /// <param name="onValue">The asynchronous function to execute if the state is a value.</param>
+    /// <param name="onFirstError">The asynchronous function to execute with the first error if the state is an error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>A task representing the asynchronous operation that yields the result of the executed function.</returns>
+    public async Task<TNextValue> MatchFirstWithMetadataAsync<TNextValue>(Func<TValue, Task<TNextValue>> onValue, Func<Error, Task<TNextValue>> onFirstError, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedError = FirstError with { Metadata = metadata };
+            return await onFirstError(enhancedError).ConfigureAwait(false);
+        }
+
+        return await onValue(Value).ConfigureAwait(false);
+    }
 }

--- a/src/ErrorOr/ErrorOr.Switch.cs
+++ b/src/ErrorOr/ErrorOr.Switch.cs
@@ -75,4 +75,86 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
         await onValue(Value).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Executes the appropriate action based on the state of the <see cref="ErrorOr{TValue}"/>.
+    /// If the state is an error, the provided action <paramref name="onError"/> is executed with metadata.
+    /// If the state is a value, the provided action <paramref name="onValue"/> is executed.
+    /// </summary>
+    /// <param name="onValue">The action to execute if the state is a value.</param>
+    /// <param name="onError">The action to execute if the state is an error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    public void SwitchWithMetadata(Action<TValue> onValue, Action<List<Error>> onError, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+            onError(enhancedErrors);
+            return;
+        }
+
+        onValue(Value);
+    }
+
+    /// <summary>
+    /// Asynchronously executes the appropriate action based on the state of the <see cref="ErrorOr{TValue}"/>.
+    /// If the state is an error, the provided action <paramref name="onError"/> is executed asynchronously with metadata.
+    /// If the state is a value, the provided action <paramref name="onValue"/> is executed asynchronously.
+    /// </summary>
+    /// <param name="onValue">The asynchronous action to execute if the state is a value.</param>
+    /// <param name="onError">The asynchronous action to execute if the state is an error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task SwitchWithMetadataAsync(Func<TValue, Task> onValue, Func<List<Error>, Task> onError, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+            await onError(enhancedErrors).ConfigureAwait(false);
+            return;
+        }
+
+        await onValue(Value).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Executes the appropriate action based on the state of the <see cref="ErrorOr{TValue}"/>.
+    /// If the state is an error, the provided action <paramref name="onFirstError"/> is executed with metadata using the first error as input.
+    /// If the state is a value, the provided action <paramref name="onValue"/> is executed.
+    /// </summary>
+    /// <param name="onValue">The action to execute if the state is a value.</param>
+    /// <param name="onFirstError">The action to execute with the first error if the state is an error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    public void SwitchFirstWithMetadata(Action<TValue> onValue, Action<Error> onFirstError, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedError = FirstError with { Metadata = metadata };
+            onFirstError(enhancedError);
+            return;
+        }
+
+        onValue(Value);
+    }
+
+    /// <summary>
+    /// Asynchronously executes the appropriate action based on the state of the <see cref="ErrorOr{TValue}"/>.
+    /// If the state is an error, the provided action <paramref name="onFirstError"/> is executed asynchronously with metadata using the first error as input.
+    /// If the state is a value, the provided action <paramref name="onValue"/> is executed asynchronously.
+    /// </summary>
+    /// <param name="onValue">The asynchronous action to execute if the state is a value.</param>
+    /// <param name="onFirstError">The asynchronous action to execute with the first error if the state is an error.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task SwitchFirstWithMetadataAsync(Func<TValue, Task> onValue, Func<Error, Task> onFirstError, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedError = FirstError with { Metadata = metadata };
+            await onFirstError(enhancedError).ConfigureAwait(false);
+            return;
+        }
+
+        await onValue(Value).ConfigureAwait(false);
+    }
 }

--- a/src/ErrorOr/ErrorOr.Then.cs
+++ b/src/ErrorOr/ErrorOr.Then.cs
@@ -99,4 +99,118 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
 
         return await onValue(Value).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed and its result is returned,
+    /// including additional metadata for enhanced error handling.
+    /// </summary>
+    /// <typeparam name="TNextValue">The type of the result.</typeparam>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The result from calling <paramref name="onValue"/> if state is value; otherwise the original <see cref="Errors"/> with metadata.</returns>
+    public ErrorOr<TNextValue> ThenWithMetadata<TNextValue>(Func<TValue, ErrorOr<TNextValue>> onValue, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+            return enhancedErrors;
+        }
+
+        return onValue(Value);
+    }
+
+    /// <summary>
+    /// If the state is a value, the provided <paramref name="action"/> is invoked, including additional metadata for enhanced error handling.
+    /// </summary>
+    /// <param name="action">The action to execute if the state is a value.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The original <see cref="ErrorOr"/> instance with metadata.</returns>
+    public ErrorOr<TValue> ThenDoWithMetadata(Action<TValue> action, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+            return enhancedErrors;
+        }
+
+        action(Value);
+
+        return this;
+    }
+
+    /// <summary>
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed and its result is returned,
+    /// including additional metadata for enhanced error handling.
+    /// </summary>
+    /// <typeparam name="TNextValue">The type of the result.</typeparam>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The result from calling <paramref name="onValue"/> if state is value; otherwise the original <see cref="Errors"/> with metadata.</returns>
+    public ErrorOr<TNextValue> ThenWithMetadata<TNextValue>(Func<TValue, TNextValue> onValue, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+            return enhancedErrors;
+        }
+
+        return onValue(Value);
+    }
+
+    /// <summary>
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its result is returned,
+    /// including additional metadata for enhanced error handling.
+    /// </summary>
+    /// <typeparam name="TNextValue">The type of the result.</typeparam>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The result from calling <paramref name="onValue"/> if state is value; otherwise the original <see cref="Errors"/> with metadata.</returns>
+    public async Task<ErrorOr<TNextValue>> ThenWithMetadataAsync<TNextValue>(Func<TValue, Task<ErrorOr<TNextValue>>> onValue, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+            return enhancedErrors;
+        }
+
+        return await onValue(Value).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// If the state is a value, the provided <paramref name="action"/> is invoked asynchronously, including additional metadata for enhanced error handling.
+    /// </summary>
+    /// <param name="action">The action to execute if the state is a value.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The original <see cref="ErrorOr"/> instance with metadata.</returns>
+    public async Task<ErrorOr<TValue>> ThenDoWithMetadataAsync(Func<TValue, Task> action, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+            return enhancedErrors;
+        }
+
+        await action(Value).ConfigureAwait(false);
+
+        return this;
+    }
+
+    /// <summary>
+    /// If the state is a value, the provided function <paramref name="onValue"/> is executed asynchronously and its result is returned,
+    /// including additional metadata for enhanced error handling.
+    /// </summary>
+    /// <typeparam name="TNextValue">The type of the result.</typeparam>
+    /// <param name="onValue">The function to execute if the state is a value.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>The result from calling <paramref name="onValue"/> if state is value; otherwise the original <see cref="Errors"/> with metadata.</returns>
+    public async Task<ErrorOr<TNextValue>> ThenWithMetadataAsync<TNextValue>(Func<TValue, Task<TNextValue>> onValue, Dictionary<string, object> metadata)
+    {
+        if (IsError)
+        {
+            var enhancedErrors = Errors.Select(e => e with { Metadata = metadata }).ToList();
+            return enhancedErrors;
+        }
+
+        return await onValue(Value).ConfigureAwait(false);
+    }
 }

--- a/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
+++ b/src/ErrorOr/ErrorOr.ToErrorOrExtensions.cs
@@ -37,4 +37,54 @@ public static partial class ErrorOrExtensions
     {
         return errors;
     }
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="value"/> and additional metadata.
+    /// </summary>
+    /// <param name="value">The value to wrap.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing the provided value and metadata.</returns>
+    public static ErrorOr<TValue> ToErrorOrWithMetadata<TValue>(this TValue value, Dictionary<string, object> metadata)
+    {
+        return new ErrorOr<TValue>(value) with { Metadata = metadata };
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="error"/> and additional metadata.
+    /// </summary>
+    /// <param name="error">The error to wrap.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing the provided error and metadata.</returns>
+    public static ErrorOr<TValue> ToErrorOrWithMetadata<TValue>(this Error error, Dictionary<string, object> metadata)
+    {
+        return new ErrorOr<TValue>(error) with { Metadata = metadata };
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="errors"/> and additional metadata.
+    /// </summary>
+    /// <param name="errors">The list of errors to wrap.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing the provided errors and metadata.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty list.</exception>
+    public static ErrorOr<TValue> ToErrorOrWithMetadata<TValue>(this List<Error> errors, Dictionary<string, object> metadata)
+    {
+        var enhancedErrors = errors.Select(e => e with { Metadata = metadata }).ToList();
+        return new ErrorOr<TValue>(enhancedErrors);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> instance with the given <paramref name="errors"/> and additional metadata.
+    /// </summary>
+    /// <param name="errors">The array of errors to wrap.</param>
+    /// <param name="metadata">Additional metadata to include with the errors.</param>
+    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing the provided errors and metadata.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="errors"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="errors" /> is an empty array.</exception>
+    public static ErrorOr<TValue> ToErrorOrWithMetadata<TValue>(this Error[] errors, Dictionary<string, object> metadata)
+    {
+        var enhancedErrors = errors.Select(e => e with { Metadata = metadata }).ToList();
+        return new ErrorOr<TValue>(enhancedErrors);
+    }
 }

--- a/src/ErrorOr/ErrorOr.cs
+++ b/src/ErrorOr/ErrorOr.cs
@@ -131,4 +131,49 @@ public readonly partial record struct ErrorOr<TValue> : IErrorOr<TValue>
     {
         return new ErrorOr<TValue>(value);
     }
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> from a tuple.
+    /// </summary>
+    /// <param name="tuple">The tuple to create the <see cref="ErrorOr{TValue}"/> from.</param>
+    /// <returns>An <see cref="ErrorOr{TValue}"/> instance containing the provided value or errors.</returns>
+    public static ErrorOr<TValue> FromTuple((TValue? Value, List<Error>? Errors) tuple)
+    {
+        if (tuple.Errors is not null)
+        {
+            return new ErrorOr<TValue>(tuple.Errors);
+        }
+
+        if (tuple.Value is not null)
+        {
+            return new ErrorOr<TValue>(tuple.Value);
+        }
+
+        throw new ArgumentException("The tuple must contain either a value or errors.", nameof(tuple));
+    }
+
+    /// <summary>
+    /// Creates an <see cref="ErrorOr{TValue}"/> from a custom object.
+    /// </summary>
+    /// <typeparam name="TCustom">The type of the custom object.</typeparam>
+    /// <param name="customObject">The custom object to create the <see cref="ErrorOr{TValue}"/> from.</param>
+    /// <param name="valueSelector">The function to select the value from the custom object.</param>
+    /// <param name="errorsSelector">The function to select the errors from the custom object.</param>
+    /// <returns>An <see cref="ErrorOr{TValue}"/> instance containing the provided value or errors.</returns>
+    public static ErrorOr<TValue> FromCustom<TCustom>(TCustom customObject, Func<TCustom, TValue?> valueSelector, Func<TCustom, List<Error>?> errorsSelector)
+    {
+        var errors = errorsSelector(customObject);
+        if (errors is not null)
+        {
+            return new ErrorOr<TValue>(errors);
+        }
+
+        var value = valueSelector(customObject);
+        if (value is not null)
+        {
+            return new ErrorOr<TValue>(value);
+        }
+
+        throw new ArgumentException("The custom object must contain either a value or errors.", nameof(customObject));
+    }
 }

--- a/src/ErrorOr/ErrorOrFactory.cs
+++ b/src/ErrorOr/ErrorOrFactory.cs
@@ -15,4 +15,29 @@ public static class ErrorOrFactory
     {
         return value;
     }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ErrorOr{TValue}"/> from a tuple.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <param name="tuple">The tuple containing the value and errors.</param>
+    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing the provided value or errors.</returns>
+    public static ErrorOr<TValue> FromTuple<TValue>((TValue? Value, List<Error>? Errors) tuple)
+    {
+        return ErrorOr<TValue>.FromTuple(tuple);
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ErrorOr{TValue}"/> from a custom object.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value.</typeparam>
+    /// <typeparam name="TCustom">The type of the custom object.</typeparam>
+    /// <param name="customObject">The custom object containing the value and errors.</param>
+    /// <param name="valueSelector">The function to select the value from the custom object.</param>
+    /// <param name="errorsSelector">The function to select the errors from the custom object.</param>
+    /// <returns>An instance of <see cref="ErrorOr{TValue}"/> containing the provided value or errors.</returns>
+    public static ErrorOr<TValue> FromCustom<TValue, TCustom>(TCustom customObject, Func<TCustom, TValue?> valueSelector, Func<TCustom, List<Error>?> errorsSelector)
+    {
+        return ErrorOr<TValue>.FromCustom(customObject, valueSelector, errorsSelector);
+    }
 }

--- a/src/Errors/Error.cs
+++ b/src/Errors/Error.cs
@@ -124,6 +124,30 @@ public readonly record struct Error
         new(code, description, ErrorType.Forbidden, metadata);
 
     /// <summary>
+    /// Creates an <see cref="Error"/> of type <see cref="ErrorType.BadRequest"/> from a code and description.
+    /// </summary>
+    /// <param name="code">The unique error code.</param>
+    /// <param name="description">The error description.</param>
+    /// <param name="metadata">A dictionary which provides optional space for information.</param>
+    public static Error BadRequest(
+        string code = "General.BadRequest",
+        string description = "A 'Bad Request' error has occurred.",
+        Dictionary<string, object>? metadata = null) =>
+        new(code, description, ErrorType.BadRequest, metadata);
+
+    /// <summary>
+    /// Creates an <see cref="Error"/> of type <see cref="ErrorType.InternalServerError"/> from a code and description.
+    /// </summary>
+    /// <param name="code">The unique error code.</param>
+    /// <param name="description">The error description.</param>
+    /// <param name="metadata">A dictionary which provides optional space for information.</param>
+    public static Error InternalServerError(
+        string code = "General.InternalServerError",
+        string description = "An 'Internal Server Error' has occurred.",
+        Dictionary<string, object>? metadata = null) =>
+        new(code, description, ErrorType.InternalServerError, metadata);
+
+    /// <summary>
     /// Creates an <see cref="Error"/> with the given numeric <paramref name="type"/>,
     /// <paramref name="code"/>, and <paramref name="description"/>.
     /// </summary>

--- a/src/Errors/ErrorType.cs
+++ b/src/Errors/ErrorType.cs
@@ -12,4 +12,6 @@ public enum ErrorType
     NotFound,
     Unauthorized,
     Forbidden,
+    BadRequest,
+    InternalServerError
 }

--- a/src/Results/Results.cs
+++ b/src/Results/Results.cs
@@ -6,6 +6,8 @@ public readonly record struct Success;
 public readonly record struct Created;
 public readonly record struct Deleted;
 public readonly record struct Updated;
+public readonly record struct Accepted;
+public readonly record struct NoContent;
 
 public static class Result
 {
@@ -16,4 +18,8 @@ public static class Result
     public static Deleted Deleted => default;
 
     public static Updated Updated => default;
+
+    public static Accepted Accepted => default;
+
+    public static NoContent NoContent => default;
 }


### PR DESCRIPTION
Enhance the `ErrorOr` functionality by adding new methods and updating existing ones.

* **README.md**:
  - Add a section on enhancements related to the `ErrorOr` functionality.
  - Mention the new methods and their usage.

* **src/ErrorOr/ErrorOr.AggregationExtensions.cs**:
  - Add `AppendErrorsWithMetadata` method to append errors with additional metadata.

* **src/ErrorOr/ErrorOr.cs**:
  - Add `FromTuple` method to create `ErrorOr` instances from tuples.
  - Add `FromCustom` method to create `ErrorOr` instances from custom objects.

* **src/ErrorOr/ErrorOr.Else.cs**:
  - Add `ElseWithMetadata` and `ElseWithMetadataAsync` methods to handle errors with additional metadata.

---
